### PR TITLE
[DOC-12546]: Fix the expansion on the Kafka Connector menu item

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,4 +1,4 @@
-.xref:index.adoc[Kafka Connector]
+* xref:index.adoc[]
 * xref:quickstart.adoc[Quickstart]
 * xref:delivery-guarantees.adoc[Delivery Guarantees]
 * xref:source-configuration-options.adoc[Source Configuration Options]


### PR DESCRIPTION

Removed superfluous top-level menu item.
Changed the item to an `introduction`.