### PR TITLE
Release notes and doc updates for 4.2.6

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -26,10 +26,10 @@ When developing a custom component, include the connector's Java API in your Mav
 </dependency>
 ----
 
-[[v4.2.5]]
-== Version 4.2.5 (19 Nov 2024)
+[[v4.2.6]]
+== Version 4.2.6 (21 Nov 2024)
 
-https://packages.couchbase.com/clients/kafka/4.2.5/couchbase-kafka-connect-couchbase-4.2.5.zip[Download]
+https://packages.couchbase.com/clients/kafka/4.2.6/couchbase-kafka-connect-couchbase-4.2.6.zip[Download]
 
 In addition to the usual dependency version bumps, this release adds the ability to include Couchbase document metadata in Kafka record headers, regardless of which `SourceHandler` is used.
 


### PR DESCRIPTION
pulling 4.2.5 (it's unusable) and jumping straight to 4.2.6