### PR TITLE
Fix formatting of initial offset tombstone document ID

### DIFF
--- a/modules/ROOT/pages/generated-source-config-reference.adoc
+++ b/modules/ROOT/pages/generated-source-config-reference.adoc
@@ -334,7 +334,12 @@ If `couchbase.stream.from` is `SAVED_OFFSET_OR_NOW`, and this property is non-bl
 
 This lets the connector initialize the missing source offsets to "now" (the current state of Couchbase).
 
-The synthetic records have a value of null, and the same key: `__COUCHBASE_INITIAL_OFFSET_TOMBSTONE__a54ee32b-4a7e-4d98-aa36-45d8417e942a`.
+The synthetic records have a value of null, and the same key:
+
+[source]
+----
+__COUCHBASE_INITIAL_OFFSET_TOMBSTONE__a54ee32b-4a7e-4d98-aa36-45d8417e942a
+----
 
 Consumers of this topic must ignore (or tolerate) these records.
 


### PR DESCRIPTION
Use a source block to prevent the underscores in the document name from being interpreted as formatting